### PR TITLE
Replace blossom-cli and blossom-server with gnostr

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -311,8 +311,8 @@ jobs:
       run: |
         mkdir -p "$BUILD_NAME"
         cp README.md LICENSE "$BUILD_NAME/"
-        cp "target/${{ matrix.target }}/release/blossom-cli" "$BUILD_NAME/"
-        cp "target/${{ matrix.target }}/release/blossom-server" "$BUILD_NAME/"
+        cp "target/${{ matrix.target }}/release/gnostr" "$BUILD_NAME/"
+        cp "target/${{ matrix.target }}/release/gnostr" "$BUILD_NAME/"
 
     - name: Bundle release (Windows)
       if: matrix.build == 'windows-x64'
@@ -320,22 +320,22 @@ jobs:
       run: |
         mkdir -p "$BUILD_NAME"
         cp README.md LICENSE "$BUILD_NAME/"
-        cp "target/${{ matrix.target }}/release/blossom-cli.exe" "$BUILD_NAME/"
-        cp "target/${{ matrix.target }}/release/blossom-server.exe" "$BUILD_NAME/"
+        cp "target/${{ matrix.target }}/release/gnostr.exe" "$BUILD_NAME/"
+        cp "target/${{ matrix.target }}/release/gnostr.exe" "$BUILD_NAME/"
 
     - name: Run smoke test (Unix)
       if: matrix.native && matrix.build != 'windows-x64'
       shell: bash
       run: |
-        "$BUILD_NAME/blossom-cli" --version
-        "$BUILD_NAME/blossom-server" --version
+        "$BUILD_NAME/gnostr" --version
+        "$BUILD_NAME/gnostr" --version
 
     - name: Run smoke test (Windows)
       if: matrix.native && matrix.build == 'windows-x64'
       shell: bash
       run: |
-        "$BUILD_NAME/blossom-cli.exe" --version
-        "$BUILD_NAME/blossom-server.exe" --version
+        "$BUILD_NAME/gnostr.exe" --version
+        "$BUILD_NAME/gnostr.exe" --version
 
     - name: Upload asset
       uses: actions/upload-artifact@v4
@@ -356,12 +356,12 @@ jobs:
         include:
           - image: ghcr.io/gnostr-org/gnostr
             file: docker/Dockerfile.gnostr
-          - image: ghcr.io/gnostr-org/gnostr-node
-            file: docker/Dockerfile.gnostr-node
-          - image: ghcr.io/gnostr-org/blossom-server
-            file: docker/Dockerfile.blossom-server
-          - image: ghcr.io/gnostr-org/blossom-git
-            file: docker/Dockerfile.blossom-git
+          #- image: ghcr.io/gnostr-org/gnostr-node
+          #  file: docker/Dockerfile.gnostr-node
+          #- image: ghcr.io/gnostr-org/blossom-server
+          #  file: docker/Dockerfile.blossom-server
+          #- image: ghcr.io/gnostr-org/blossom-git
+          #  file: docker/Dockerfile.blossom-git
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated build artifact workflow to use 'gnostr' instead of 'blossom-cli' and 'blossom-server'.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
-
-

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog